### PR TITLE
fix(license): check versions when npm.license is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,11 +43,13 @@
     "date-fns": "^1.28.5",
     "lodash.flatten": "^4.4.0",
     "lodash.includes": "^4.3.0",
-    "node-fetch": "^1.7.1"
+    "node-fetch": "^1.7.1",
+    "semver": "^5.4.1"
   },
   "devDependencies": {
     "@types/jest": "^19.2.4",
     "@types/node": "^7.0.29",
+    "@types/semver": "^5.3.33",
     "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.0.0",
     "danger": "*",

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -9,183 +9,62 @@ exports[`npm metadata Shows a bunch of useful text for a new dep 1`] = `
 
 <table>
   <thead><tr><th></th><th width=\\"100%\\"></th></tr></thead>
-  <tr><td>Created</td><td>about 1 year ago</td></tr><tr><td>Last Updated</td><td>2 months ago</td></tr><tr><td>License</td><td>MIT</td></tr><tr><td>Maintainers</td><td>3</td></tr><tr><td>Releases</td><td>45</td></tr><tr><td>Direct Dependencies</td><td>undefined</td></tr><tr><td>Keywords</td><td>undefined</td></tr>
+  <tr><td>Created</td><td>about 1 year ago</td></tr><tr><td>Last Updated</td><td>2 days ago</td></tr><tr><td>License</td><td>MIT</td></tr><tr><td>Maintainers</td><td>3</td></tr><tr><td>Releases</td><td>58</td></tr><tr><td>Direct Dependencies</td><td>undefined</td></tr><tr><td>Keywords</td><td>undefined</td></tr>
 </table>
 
 <details>
 <summary><code>README</code></summary>
-[![npm](https://img.shields.io/npm/v/danger.svg)](https://www.npmjs.com/package/danger)
-[![Build Status](https://travis-ci.org/danger/danger-js.svg?branch=master)](https://travis-ci.org/danger/danger-js)
-[![Build Status](https://ci.appveyor.com/api/projects/status/ep5hgeox3lbc5c7f?svg=true)](https://ci.appveyor.com/project/orta/danger-js/branch/master)
+# Danger JS :no_entry_sign: [![npm](https://img.shields.io/npm/v/danger.svg)](https://www.npmjs.com/package/danger) [![Build Status](https://travis-ci.org/danger/danger-js.svg?branch=master)](https://travis-ci.org/danger/danger-js) [![Build Status](https://ci.appveyor.com/api/projects/status/ep5hgeox3lbc5c7f?svg=true)](https://ci.appveyor.com/project/orta/danger-js/branch/master)
 
-Danger on Node, wonder what's going on? see [VISION.md](VISION.md)
+Formalize your Pull Request etiquette.
 
-*Welcome!*
+<p align=\\"center\\">
+    <a href=\\"#what-is-danger-js\\">What is Danger JS?</a> &bull;
+    <a href=\\"VISION.md\\">Vision</a> &bull;
+    <a href=\\"#this-thing-is-broken-i-should-help-improve-it\\">Helping Out</a> &bull;
+    <a href=\\"http://danger.systems/js/usage/extending-danger.html\\">Plugin Development</a>
+</p>
 
-So, what's the deal? Well, right now Danger JS does a lot of the simpler parts of [the Ruby version](http://danger.systems).
-You can look at [Git](https://github.com/danger/danger-js/blob/master/source/dsl/GitDSL.ts) metadata, or [GitHub](https://github.com/danger/danger-js/blob/master/source/dsl/GitHubDSL.ts) metadata on Travis CI, Circle CI, Semaphore, Jenkins, Docker Cloud, surf-build, Codeship, Drone, or Buildkite.
+## What is Danger JS?
 
-Danger can fail your build, write a comment on GitHub, edit it as your PR changes and then delete it once you've passed review. Perfect.
+Danger runs after your CI, automating your team's conventions surrounding code review.
 
-## Getting set up in your Project
+This provides another logical step in your process, through this Danger can help lint your rote tasks in daily code review.
 
-\`\`\`sh
-# with yarn
-yarn add danger --dev
+You can use Danger to codify your teams norms, leaving humans to think about harder problems.
 
-# or with npm
-npm install --save-dev danger
-\`\`\`
+Danger JS currently works with GitHub and Travis CI, Circle CI, Semaphore, Jenkins, Docker Cloud, surf-build, Codeship, Drone, Buildkite, buddybuild or Visual Studio Team Services.
 
-If using NPM, add a run command to your \`package.json\`
+## For example?
 
-\`\`\`json
-{
-  \\"scripts\\": {
-    \\"danger\\": \\"danger\\"  
-  }
-}
-\`\`\`
+You can:
 
-Then create a \`dangerfile.js\` in the project root with some rules:
+-   Enforce CHANGELOGs
+-   Enforce links to Trello/JIRA in PR/MR bodies
+-   Enforce using descriptive labels
+-   Look out for common anti-patterns
+-   Highlight interesting build artifacts
+-   Give warnings when specific files change
 
-\`\`\`js
-import { danger, fail, warn } from \\"danger\\"
-import fs from \\"fs\\"
+Danger provides the glue to let _you_ build out the rules specific to your team's culture, offering useful metadata and a comprehensive plugin system to share common issues.
 
-// Make sure there are changelog entries
-const hasChangelog = danger.git.modified_files.includes(\\"changelog.md\\")
-if (!hasChangelog) { fail(\\"No Changelog changes!\\") }
+## Getting Started
 
-const jsFiles = danger.git.created_files.filter(path => path.endsWith(\\"js\\"))
+Alright. So, actually, you may be in the wrong place. From here on in, this README is going to be for people who are interested in working on and improving on Danger JS.
 
-// new js files should have \`@flow\` at the top
-const unFlowedFiles = jsFiles.filter(filepath => {
-  const content = fs.readFileSync(filepath)
-  return !content.includes(\\"@flow\\")
-})
+We keep all of the end-user documentation at <http://danger.systems/js>.
 
-if (unFlowedFiles.length > 0) {
-  warn(\`These new JS files do not have Flow enabled: \${unFlowedFiles.join(\\", \\")}\`)
-}
-\`\`\`
+Some quick links to get you started:
 
-You can also write your Dangerfile in TypeScript. Create \`dangerfile.ts\` in the project root with some rules:
-
-\`\`\`ts
-import { danger, warn } from \\"danger\\"
-import * as _ from \\"lodash\\"
-
-// Request a CHANGELOG entry if not declared #trivial
-const hasChangelog = _.includes(danger.git.modified_files, \\"changelog.md\\")
-const isTrivial = _.includes((danger.github.pr.body + danger.github.pr.title), \\"#trivial\\")
-if (!hasChangelog && !isTrivial) {
-  warn(\\"Please add a changelog entry for your changes.\\")
-
-  // Politely ask for their name on the entry too
-  const changelogDiff = danger.git.diffForFile(\\"changelog.md\\")
-  const contributorName = danger.github.pr.user.login
-  if (changelogDiff && _.includes(changelogDiff, contributorName)) {
-    warn(\\"Please add your GitHub name to the changelog entry, so we can attribute you correctly.\\")
-  }
-}
-\`\`\`
-
-Using [Jest][jest] and TypeScript for testing? You're all set - Danger should be able to use your \`jest\` config in \`package.json\` to process and evaulate your \`dangerfile.ts\`.
-
-Not using Jest on your TypeScript project? You'll need to take the following steps for danger to evaluate your \`dangerfile.ts\`:
-
-* Install the \`ts-jest\` package - \`yarn add ts-jest --dev\`
-* Add the following \`jest\` section to your \`package.json\`
-
-\`\`\`json
-{
-  \\"jest\\": {
-    \\"transform\\": {
-      \\".(ts|tsx)\\": \\"<rootDir>/node_modules/ts-jest/preprocessor.js\\"
-    }
-  }
-}
-\`\`\`
-
-Then you add \`yarn run danger\` to the end of your CI run, and Danger will run. Here's [an example](https://github.com/artsy/emission/pull/385). 👍
-
-Want to see some existing JavaScript examples? Check out:
-
-* **Apps** - [Artsy/metaphysics][meta].
-* **Libraries** - [Facebook/Jest][fbj], [styled-components/styled-components][sc] and [ReactiveX/rxjs][rxjs].
-
-Some TypeScript examples:
-
-* **Apps** - [Artsy/Emission][emiss]
-* **Libraries** [danger/danger-js][danger-js]
-
-I'd love PRs adding more.
-
-## Getting set up on CI
-
-For now, to get set up I'd recommend looking at [the setup guide for the Ruby version][setup]. All the environment vars are the exact same between versions.
-
-You will need to create a bot account, and set up CI to run danger.
-
-If you are using Docker Cloud, make sure to set the following blank ENV vars in your \`docker-compose.test.yml\` file so they are carried forward from the build environment:
-
-\`\`\`yml
-sut:
-  build: .
-  environment:
-    - DANGER_GITHUB_API_TOKEN
-    - DOCKER_REPO
-    - PULL_REQUEST_URL
-    - SOURCE_REPOSITORY_URL
-\`\`\`
-
-## Running/Testing manually against a repo
-
-There are two ways to do this:
-
-#### Using \`danger pr\`
-
-The command \`danger pr\` expects an argument of a PR url, e.g. \`danger pr https://github.com/danger/danger-js/pull/100\`.
-
-This will use your local \`dangerfile.js\` against the metadata of that PR. Danger will then output the results as JSON, instead of on the PR itself.
-
-#### Using \`danger\`
-
-If you create an [appropriately scoped temporary api token](http://danger.systems/guides/getting_started.html#setting-up-an-access-token) for your github account, this can be a good way to see if danger is suitable for you before integrating it into your CI system.
-
-You can manually trigger danger against a pull request on the command line by setting the following environmental variables:
-
-\`\`\`bash
-export DANGER_FAKE_CI=\\"YEP\\"
-export DANGER_GITHUB_API_TOKEN='xxxxxxxxxx'  # a github api token
-export DANGER_TEST_REPO='username/reponame'
-\`\`\`
-
-Then you can run against a local branch that is attached to a pull-request, by running the following
-
-\`\`\`bash
-git checkout branch-for-pr-1234
-DANGER_TEST_PR='1234' npm run danger
-\`\`\`
-
-assuming that your local file-system matches up to that branch on github, this will be a good approximation of how danger will work when you integrate it into your CI system.
-
-Note: this will leave a comment on the PR.
-
-## Advice
-
-* You can have Danger read build logs if you use [tee](https://en.wikipedia.org/wiki/Tee_(command)) in your CI process: \`yarn run lint | tee linter_output.txt\`. This can then be picked up with \`readFileSync\` at \`linter_output.txt\` in your Dangerfile later.
-
-## Known issues
-
-* Codeship support does not support fork to fork GitHub PRs.
+-   [Getting Started](http://danger.systems/js/guides/getting_started.html) 
+-   [Guides Index](http://danger.systems/js/guides.html)
+-   [DSL Reference](http://danger.systems/js/reference.html)
 
 ## This thing is broken, I should help improve it!
 
 Awesommmmee.
 
-\`\`\` sh
+\`\`\`sh
 git clone https://github.com/danger/danger-js.git
 cd danger-js
 
@@ -197,43 +76,120 @@ yarn install
 
 You can then verify your install by running the tests, and the linters:
 
-\`\`\` sh
+\`\`\`sh
 yarn test
 yarn lint
 \`\`\`
 
----
-
-### Dev Life
-
-Tips:
-
-* You can run the \`danger\` command globally from your dev build by running \`yarn run link\`.
-* If you're using VS Code, press Run to start an example run, should go through most of the process with a debugger attached. Either use breakpoints, or add \`debugger\` to get a repl and context.
+The fixers for both tslint and prettier will be applied when you commit, and on a push your code will be verified
+that it compiles.
 
 ### What is the TODO?
 
 Check the issues, I try and keep my short term perspective there. Long term is in the [VISION.md](VISION.md).
+
+### Releasing a new version of Danger
+
+Following [this commit](https://github.com/danger/danger-js/commit/a26ac3b3bd4f002acd37f6a363c8e74c9d5039ab) as a model:
+
+-   Checkout the \`master\` branch. Ensure your working tree is clean, and make sure you have the latest changes by running \`git pull\`.
+-   Update \`package.json\` with the new version - for the sake of this example, the new version is **0.21.0**.
+-   Modify \`changelog.md\`, adding a new \`### 0.21.0\` heading under the \`### Master\` heading at the top of the file.
+-   Commit both changes with the commit message **Version bump**.
+-   Tag this commit - \`git tag 0.21.0\`.
+-   Push the commit and tag to master - \`git push origin master --follow-tags\`. Travis CI will build the tagged commit and publish that tagged version to NPM.
+
+:ship:
 
 ## License, Contributor's Guidelines and Code of Conduct
 
 We try to keep as much discussion as possible in GitHub issues, but also have a pretty inactive Slack --- if you'd like an invite, ping [@Orta](https://twitter.com/orta/) a DM on Twitter with your email. It's mostly interesting if you want to stay on top of Danger without all the emails from GitHub.
 
 > This project is open source under the MIT license, which means you have full access to the source code and can modify it to fit your own needs.
-
+>
 > This project subscribes to the [Moya Contributors Guidelines](https://github.com/Moya/contributors) which TLDR: means we give out push access easily and often.
-
+>
 > Contributors subscribe to the [Contributor Code of Conduct](http://contributor-covenant.org/version/1/3/0/) based on the [Contributor Covenant](http://contributor-covenant.org) version 1.3.0.
 
 [emiss]: https://github.com/artsy/emission/blob/master/dangerfile.ts
+
 [danger-js]: https://github.com/danger/danger-js/blob/master/dangerfile.ts
+
 [meta]: https://github.com/artsy/metaphysics/blob/master/dangerfile.js
+
 [fbj]: https://github.com/facebook/jest/blob/master/dangerfile.js
+
 [sc]: https://github.com/styled-components/styled-components/blob/master/dangerfile.js
+
 [rxjs]: https://github.com/ReactiveX/rxjs/blob/master/dangerfile.js
+
 [setup]: http://danger.systems/guides/getting_started.html#creating-a-bot-account-for-danger-to-use
+
 [jest]: https://github.com/facebook/jest
 
+</details>
+
+"
+`;
+
+exports[`npm metadata looks through versions if license is missing 1`] = `
+"
+<h2><a href=\\"http://npmjs.com/package/pinpoint\\">pinpoint</a></h2>
+<p>Author: Glen Huang</p>
+<p>Description: Display an arrow in a string of code to point to a location</p>
+<p>Homepage: <a href=\\"http://npmjs.com/package/pinpoint\\">http://npmjs.com/package/pinpoint</a></p>
+
+<table>
+  <thead><tr><th></th><th width=\\"100%\\"></th></tr></thead>
+  <tr><td>Created</td><td>almost 4 years ago</td></tr><tr><td>Last Updated</td><td>almost 4 years ago</td></tr><tr><td>License</td><td><b>MIT</b></td></tr><tr><td>Maintainers</td><td>1</td></tr><tr><td>Releases</td><td>2</td></tr>
+</table>
+
+<details>
+<summary><code>README</code></summary>
+# pinpoint
+
+Add line numbers and an arrow to a string of code that points to a specific location.
+
+## Installation
+
+	npm install pinpoint
+
+## Example
+
+With this code:
+
+\`\`\`javascript
+function add(left, right) {
+  return left + right;
+}
+
+console.log(add(1 + 1));
+\`\`\`
+
+When being asked to point to line 2 and column 2, generates this:
+
+\`\`\`javascript
+1| function add(left, right) {
+2|   return left + right;
+-----^
+3| }
+4|
+5| console.log(add(1 + 1));
+\`\`\`
+## API
+
+\`\`\`javascript
+var pinpoint = require('pinpoint');
+
+var str = pinpoint(code, options);
+\`\`\`
+
+* \`code\` - a string of code
+* \`options\` - an object literal supports these options:
+	* \`line\` - the line number to point to, 1-based.
+	* \`column\` - the column number to point to, 1-based.
+	* \`showLines\` - the number of lines to show. The pointed line will try to stay in the middle of the displays lines.
+	* \`indent\` - indent string prepend to each line, before the line number.
 </details>
 
 "

--- a/src/fixtures/pinpoint-npm-info.json
+++ b/src/fixtures/pinpoint-npm-info.json
@@ -1,0 +1,135 @@
+{
+  "_attachments": {},
+  "_id": "pinpoint",
+  "_rev": "5-25a718426e3c3e3763b7a8f85b9fe65b",
+  "author": {
+      "email": "curvedmark@gmail.com",
+      "name": "Glen Huang"
+  },
+  "description": "Display an arrow in a string of code to point to a location",
+  "dist-tags": {
+      "latest": "1.1.0"
+  },
+  "maintainers": [
+      {
+          "email": "curvedmark@gmail.com",
+          "name": "curvedmark"
+      }
+  ],
+  "name": "pinpoint",
+  "readme": "# pinpoint\n\nAdd line numbers and an arrow to a string of code that points to a specific location.\n\n## Installation\n\n\tnpm install pinpoint\n\n## Example\n\nWith this code:\n\n```javascript\nfunction add(left, right) {\n  return left + right;\n}\n\nconsole.log(add(1 + 1));\n```\n\nWhen being asked to point to line 2 and column 2, generates this:\n\n```javascript\n1| function add(left, right) {\n2|   return left + right;\n-----^\n3| }\n4|\n5| console.log(add(1 + 1));\n```\n## API\n\n```javascript\nvar pinpoint = require('pinpoint');\n\nvar str = pinpoint(code, options);\n```\n\n* `code` - a string of code\n* `options` - an object literal supports these options:\n\t* `line` - the line number to point to, 1-based.\n\t* `column` - the column number to point to, 1-based.\n\t* `showLines` - the number of lines to show. The pointed line will try to stay in the middle of the displays lines.\n\t* `indent` - indent string prepend to each line, before the line number.",
+  "repository": {
+      "type": "git",
+      "url": "git://github.com/curvedmark/pinpoint.git"
+  },
+  "time": {
+      "1.0.0": "2013-08-19T09:30:51.336Z",
+      "1.1.0": "2013-09-21T09:56:46.195Z",
+      "created": "2013-08-19T09:30:46.479Z",
+      "modified": "2013-09-21T09:56:46.195Z"
+  },
+  "versions": {
+      "1.0.0": {
+          "_from": ".",
+          "_id": "pinpoint@1.0.0",
+          "_npmUser": {
+              "email": "curvedmark@gmail.com",
+              "name": "curvedmark"
+          },
+          "_npmVersion": "1.3.5",
+          "author": {
+              "email": "curvedmark@gmail.com",
+              "name": "Glen Huang"
+          },
+          "bugs": {
+              "url": "https://github.com/curvedmark/pinpoint/issues"
+          },
+          "description": "Display an arrow in a string of code to point to a location",
+          "devDependencies": {
+              "coffee-script": "1.x",
+              "mocha": "1.x"
+          },
+          "directories": {
+              "lib": "lib",
+              "test": "test"
+          },
+          "dist": {
+              "shasum": "11469494e0b14816e2fbebdd88ae189ac1a97288",
+              "tarball": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.0.0.tgz"
+          },
+          "keywords": [
+              "editor"
+          ],
+          "license": "MIT",
+          "main": "lib/pinpoint.js",
+          "maintainers": [
+              {
+                  "email": "curvedmark@gmail.com",
+                  "name": "curvedmark"
+              }
+          ],
+          "name": "pinpoint",
+          "readme": "# pinpoint\n\nAdd line numbers and an arrow to a string of code that points to a specific location.\n\n## Installation\n\n\tnpm install pinpoint\n\n## Example\n\nWith this code:\n\n```javascript\nfunction add(left, right) {\n  return left + right;\n}\n\nconsole.log(add(1 + 1));\n```\n\nWhen being asked to point to line 2 and column 2, generates this:\n\n```javascript\n1| function add(left, right) {\n2|   return left + right;\n-----^\n3| }\n4|\n5| console.log(add(1 + 1));\n```\n## API\n\n```javascript\nvar pinpoint = require('pinpoint');\n\nvar str = pinpoint(code, options);\n```\n\n* `code` - a string of code\n* `options` - an object literal supports these options:\n\t* `line` - the line number to point to, 1-based.\n\t* `column` - the column number to point to, 1-based.\n\t* `showLines` - the number of lines to show. The pointed line will try to stay in the middle of the displays lines.\n\t* `indent` - indent string prepend to each line, before the line number.",
+          "readmeFilename": "README.md",
+          "repository": {
+              "type": "git",
+              "url": "git://github.com/curvedmark/pinpoint.git"
+          },
+          "scripts": {
+              "test": "mocha --bail --compilers coffee:coffee-script --ui qunit"
+          },
+          "version": "1.0.0"
+      },
+      "1.1.0": {
+          "_from": ".",
+          "_id": "pinpoint@1.1.0",
+          "_npmUser": {
+              "email": "curvedmark@gmail.com",
+              "name": "curvedmark"
+          },
+          "_npmVersion": "1.3.8",
+          "author": {
+              "email": "curvedmark@gmail.com",
+              "name": "Glen Huang"
+          },
+          "bugs": {
+              "url": "https://github.com/curvedmark/pinpoint/issues"
+          },
+          "description": "Display an arrow in a string of code to point to a location",
+          "devDependencies": {
+              "coffee-script": "1.x",
+              "mocha": "1.x"
+          },
+          "directories": {
+              "lib": "lib",
+              "test": "test"
+          },
+          "dist": {
+              "shasum": "0cf7757a6977f1bf7f6a32207b709e377388e874",
+              "tarball": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz"
+          },
+          "keywords": [
+              "editor"
+          ],
+          "license": "MIT",
+          "main": "lib/pinpoint.js",
+          "maintainers": [
+              {
+                  "email": "curvedmark@gmail.com",
+                  "name": "curvedmark"
+              }
+          ],
+          "name": "pinpoint",
+          "readme": "# pinpoint\n\nAdd line numbers and an arrow to a string of code that points to a specific location.\n\n## Installation\n\n\tnpm install pinpoint\n\n## Example\n\nWith this code:\n\n```javascript\nfunction add(left, right) {\n  return left + right;\n}\n\nconsole.log(add(1 + 1));\n```\n\nWhen being asked to point to line 2 and column 2, generates this:\n\n```javascript\n1| function add(left, right) {\n2|   return left + right;\n-----^\n3| }\n4|\n5| console.log(add(1 + 1));\n```\n## API\n\n```javascript\nvar pinpoint = require('pinpoint');\n\nvar str = pinpoint(code, options);\n```\n\n* `code` - a string of code\n* `options` - an object literal supports these options:\n\t* `line` - the line number to point to, 1-based.\n\t* `column` - the column number to point to, 1-based.\n\t* `showLines` - the number of lines to show. The pointed line will try to stay in the middle of the displays lines.\n\t* `indent` - indent string prepend to each line, before the line number.\n\t* `tabSize` - width of a tab character.",
+          "readmeFilename": "README.md",
+          "repository": {
+              "type": "git",
+              "url": "git://github.com/curvedmark/pinpoint.git"
+          },
+          "scripts": {
+              "test": "mocha --bail --compilers coffee:coffee-script --ui qunit"
+          },
+          "version": "1.1.0"
+      }
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,18 +1,6 @@
 import * as mockfs from "fs"
-jest.mock("node-fetch", () => () =>
-  Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve(JSON.parse(mockfs.readFileSync("src/fixtures/danger-npm-info.json", "utf8"))),
-  }),
-)
 
-import yarn, {
-  checkForLockfileDiff,
-  checkForNewDependencies,
-  checkForRelease,
-  checkForTypesInDeps,
-  getNPMMetadataForDep,
-} from "./index"
+import yarn, { checkForLockfileDiff, checkForNewDependencies, checkForRelease, checkForTypesInDeps } from "./index"
 
 declare const global: any
 beforeEach(() => {
@@ -84,7 +72,25 @@ describe("checkForLockfileDiff", () => {
 
 describe("npm metadata", () => {
   it("Shows a bunch of useful text for a new dep", async () => {
+    jest.mock("node-fetch", () => () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(JSON.parse(mockfs.readFileSync("src/fixtures/danger-npm-info.json", "utf8"))),
+      })
+    )
+    const { getNPMMetadataForDep } = require("./")
     const data = await getNPMMetadataForDep("danger")
+    expect(data).toMatchSnapshot()
+  })
+  it("looks through versions if license is missing", async () => {
+    jest.mock("node-fetch", () => () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(JSON.parse(mockfs.readFileSync("src/fixtures/pinpoint-npm-info.json", "utf8"))),
+      })
+    )
+    const { getNPMMetadataForDep } = require("./")
+    const data = await getNPMMetadataForDep("pinpoint")
     expect(data).toMatchSnapshot()
   })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,10 @@
   version "7.0.29"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.29.tgz#ccfcec5b7135c7caf6c4ffb8c7f33102340d99df"
 
+"@types/semver@^5.3.33":
+  version "5.3.33"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.3.33.tgz#58ebb6c8c48e161e24f8901915e7184900d341f7"
+
 abab@^1.0.0, abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"
@@ -3447,6 +3451,10 @@ semver-regex@1.0.0:
 "semver@2 || 3 || 4":
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+
+semver@^5.4.1:
+  version "5.4.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 semver@~5.0.1:
   version "5.0.3"


### PR DESCRIPTION
See #5 

I wanted to contribute a fix for #5, but it looks like I'm not mocking node-fetch properly in the tests, and I believe the danger test snapshot changed to the latest danger README (aka it's fetching data from the network in the tests). If you could help out on this, that'd be awesome. I think this is the general fix desired - open to feedback! 😄 