### PR TITLE
Make <code> tags inline and remove wrapper <p> tag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -77,8 +77,8 @@ export const getYarnMetadataForDep = async dep => {
         resolve(`
   <details>
     <summary><code>yarn why ${printDep(dep)}</code> output</summary>
-    <p><code><ul><li>${messages.join("</li><li>")}
-    </li></ul></code></p>
+    <ul><li><code>${messages.join("</code></li><li><code>")}
+    </code></li></ul>
   </details>
   `)
       } else {


### PR DESCRIPTION
Two changes: instead of wrapping the `yarn why` message in `<p>` tags, which the browser will remove during parsing since they're around an `<ul>`, I just made the `<ul>` the top-level element.

The other change is that I changed the `<code>` tag from wrapping a block-level element to wrapping each list item; since the browser "fixes" the wrapping of a block-level tag by an inline tag during parsing, it wound up creating an empty `<code>` tag above the list, which bugged me. This way, it's just the contents of each `<li>` that are wrapped, as intended.

Here's an example of what this change will do:


<details>
  <summary><code>yarn why simple-plist</code> output (before)</summary>
  <p><code><ul><li>Has been hoisted to "simple-plist"</li><li>Reasons this module exists</li><li>Disk size without dependencies: "16kB"</li><li>Disk size with unique dependencies: "964kB"</li><li>Disk size with transitive dependencies: "1.59MB"</li><li>Number of shared dependencies: 6
  </li></ul></code></p>
</details>


<details>
  <summary><code>yarn why simple-plist</code> output (after)</summary>
  <ul><li><code>Has been hoisted to "simple-plist"</code></li><li><code>Reasons this module exists</code></li><li><code>Disk size without dependencies: "16kB"</code></li><li><code>Disk size with unique dependencies: "964kB"</code></li><li><code>Disk size with transitive dependencies: "1.59MB"</code></li><li><code>Number of shared dependencies: 6
  </code></li></ul>
</details>
