### PR TITLE
Support for private packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ And exports a default function to handle all of them at once.
 
 Note: async functions like the default one [have be to](http://danger.systems/js/guides/the_dangerfile.html#async) `schedule`'d by Danger.
 
+## Private packages
+
+If you want the plugin to find your private packages on npm, you need to provide an npm [authentication token](https://docs.npmjs.com/getting-started/working_with_tokens):
+
+```js
+// dangerfile.js
+import yarn from 'danger-plugin-yarn'
+
+schedule(yarn({ npmAuthToken: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }))
+```
+
 ## Changelog
 
 See the GitHub [release history](https://github.com/orta/danger-plugin-yarn/releases).

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -9,7 +9,7 @@ exports[`npm metadata Shows a bunch of useful text for a new dep 1`] = `
 
 <table>
   <thead><tr><th></th><th width=\\"100%\\"></th></tr></thead>
-  <tr><td>Created</td><td>over 1 year ago</td></tr><tr><td>Last Updated</td><td>7 months ago</td></tr><tr><td>License</td><td>MIT</td></tr><tr><td>Maintainers</td><td>3</td></tr><tr><td>Releases</td><td>45</td></tr><tr><td>Direct Dependencies</td><td>undefined</td></tr><tr><td>Keywords</td><td>undefined</td></tr>
+  <tr><td>Created</td><td>almost 2 years ago</td></tr><tr><td>Last Updated</td><td>11 months ago</td></tr><tr><td>License</td><td>MIT</td></tr><tr><td>Maintainers</td><td>3</td></tr><tr><td>Releases</td><td>45</td></tr><tr><td>Direct Dependencies</td><td>undefined</td></tr><tr><td>Keywords</td><td>undefined</td></tr>
 </table>
 
 <details>


### PR DESCRIPTION
Support for private packages by providing an npm auth token:
```javascript
schedule( yarn({ npmAuthToken: 'xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx' }) )
```

Also fixed an issue where org packages (like `@types/my-package`) was "incorrectly" encoding `@`.
 The NPM api couldn't handle that. 🤷‍♂️ 