### PR TITLE
Move esdoc to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.0.0",
     "danger": "*",
+    "esdoc": "^0.5.2",
     "husky": "^0.13.3",
     "jest": "^20.0.1",
     "lint-staged": "^3.4.1",
@@ -61,9 +62,6 @@
     "tslint": "^5.4.3",
     "typescript": "^2.3.2",
     "validate-commit-msg": "^2.12.1"
-  },
-  "optionalDependencies": {
-    "esdoc": "^0.5.2"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
As far as I can tell, esdoc is only used to generate the documentation for this plugin, so there's no need for it to be installed by consumers of danger-plugin-yarn.

I'm filing this because esdoc's bringing in two copies of cheerio into my project, one as a direct dependency of esdoc and a second one via the `ice-cap` dependency. And one of those copies is bringing in jsdom, which brings in a copy of requests, and… yeah. Altogether, removing `danger-plugin-yarn` from my devDeps reduces my on-disk size by 10MB, and I believe that most of that is due to esdoc.

Also, I ❤️ Danger! Thanks for working on it.