### PR TITLE
Fix check for @types dependency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ export const checkForTypesInDeps = packageDiff => {
   const sentence = danger.utils.sentence
 
   if (packageDiff.dependencies && packageDiff.dependencies.added) {
-    const typesDeps = packageDiff.dependencies.added.filter(d => d.startsWith("@types")).map(printDep)
+    const typesDeps = packageDiff.dependencies.added.filter(d => d.startsWith("@types/")).map(printDep)
     if (typesDeps.length) {
       const message = `@types dependencies were added to package.json, as a dependency for others.`
       const idea = `You need to move ${sentence(typesDeps)} into "devDependencies"?`


### PR DESCRIPTION
This fixes so packages with names that starts with @types... but not being a @types package will pass.