### PR TITLE
feat: add support for multiple package.json files

### DIFF
--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -9,7 +9,7 @@ exports[`npm metadata Shows a bunch of useful text for a new dep 1`] = `
 
 <table>
   <thead><tr><th></th><th width=\\"100%\\"></th></tr></thead>
-  <tr><td>Created</td><td>almost 2 years ago</td></tr><tr><td>Last Updated</td><td>11 months ago</td></tr><tr><td>License</td><td>MIT</td></tr><tr><td>Maintainers</td><td>3</td></tr><tr><td>Releases</td><td>45</td></tr><tr><td>Direct Dependencies</td><td>undefined</td></tr><tr><td>Keywords</td><td>undefined</td></tr>
+  <tr><td>Created</td><td>over 4 years ago</td></tr><tr><td>Last Updated</td><td>over 3 years ago</td></tr><tr><td>License</td><td>MIT</td></tr><tr><td>Maintainers</td><td>3</td></tr><tr><td>Releases</td><td>45</td></tr><tr><td>Direct Dependencies</td><td>undefined</td></tr><tr><td>Keywords</td><td>undefined</td></tr>
 </table>
 
 <details>

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -90,6 +90,27 @@ describe("checkForLockfileDiff", () => {
     checkForLockfileDiff(deps)
     expect(global.warn).toHaveBeenCalledTimes(0)
   })
+
+  it("detects changes from multiple package.json files", async () => {
+    global.danger.git = {
+      modified_files: ["package.json"],
+      created_files: ["packages/my-other-package/package.json"],
+      JSONDiffForFile: jest.fn(() => ({
+        dependencies: {
+          before: {},
+          after: {
+            "my-new-dependency": "^1.0.0",
+          },
+        },
+      })),
+    }
+
+    await yarn()
+
+    expect(global.warn).toHaveBeenCalledTimes(2)
+    expect(global.warn.mock.calls[0][0]).toMatch(/.*Changes were made to package.json.*/)
+    expect(global.warn.mock.calls[1][0]).toMatch(/.*Changes were made to package.json.*/)
+  })
 })
 
 describe("npm metadata", () => {


### PR DESCRIPTION
Adds support for multiple `package.json` files, which would be useful for things like monorepos. Looks like it may overlap with some of https://github.com/orta/danger-plugin-yarn/pull/18 but that's pretty old now and I guess not going in. What do you think?