### PR TITLE
fix($output-style): Removes accidental trailing curly-brace

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "danger-plugin",
     "yarn"
   ],
-  "version": "1.3.3",
+  "version": "1.4.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -238,7 +238,7 @@ We try to keep as much discussion as possible in GitHub issues, but also have a 
 
 
 </details>
-}
+
 
 
   <details>
@@ -485,6 +485,6 @@ We try to keep as much discussion as possible in GitHub issues, but also have a 
 
 
 </details>
-}
+
 "
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -362,7 +362,7 @@ export function _renderNPMTable({
   return `<table>
 ${rowContent.map(row => `<tr>${row}</tr>`).join("\n")}
 </table>
-${readme}}
+${readme}
 `
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export const checkForRelease = packageDiff => {
   }
 }
 
-interface DepDuplicationCache {
+export interface DepDuplicationCache {
   [depName: string]: {
     packageJSONPaths: string[]
     npmData: PartiallyRenderedNPMMetadata
@@ -133,7 +133,7 @@ const forwardSlashRegex = /(\/+)/g
 const wrappableURLForTextDisplay = (url: string) => (url || "").replace(forwardSlashRegex, `$1<wbr/>`)
 
 /** Represents a label / value, aka 2 cells */
-interface TableDeetNew {
+export interface TableDeetNew {
   /** Label */
   name: string
   /** Value */
@@ -142,18 +142,18 @@ interface TableDeetNew {
   colspan?: number
 }
 /** Represents arbitrary cell contents */
-interface TableDeetFormatted {
+export interface TableDeetFormatted {
   content: string
   colspan?: number
 }
 /** Represents arbitrary cell that will be dynamically replaced on final render */
-interface TableDeetPlaceholder {
+export interface TableDeetPlaceholder {
   placeholderKey: "used-in-packages"
   colspan?: number
 }
-interface TableRowBreak { break: "row-break" }
+export interface TableRowBreak { break: "row-break" }
 
-type TableDeet = TableRowBreak | TableDeetNew | TableDeetFormatted | TableDeetPlaceholder
+export type TableDeet = TableRowBreak | TableDeetNew | TableDeetFormatted | TableDeetPlaceholder
 const isTableDeetPlaceholder = (deet: TableDeet): deet is TableDeetPlaceholder => {
   return "placeholderKey" in deet
 }
@@ -164,7 +164,7 @@ const isTableRowBreak = (deet: TableDeet): deet is TableRowBreak => {
   return "break" in deet
 }
 
-interface PartiallyRenderedNPMMetadata {
+export interface PartiallyRenderedNPMMetadata {
   details: TableDeet[]
   readme: string
 }


### PR DESCRIPTION
Output had a curly brace that was either auto-completed, or fumble-fingered by myself, and I didn't
catch it in the PR where it was introduced. (from #44)