### PR TITLE
Automate npm publishing with GitHub Actions

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -1,0 +1,43 @@
+name: NPM Publish
+
+on:
+  push:
+    tags:
+      - "*.*.*"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set version variable
+        id: vars
+        run: |
+          if [[ "${GITHUB_REF#refs/heads/}" = "${GITHUB_REF}" ]]; then
+            APP_VERSION=${GITHUB_REF#refs/tags/}
+          else
+            version=$(git describe --tags --abbrev=0 || echo 0.0.0)
+            subver=${{ github.run_number }}
+            APP_VERSION=$version+b$subver
+          fi
+          echo ::set-output name=version::$APP_VERSION
+          echo "version: [$APP_VERSION]"
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: yarn prepare-release
+        env:
+          APP_VERSION: ${{ steps.vars.outputs.version }}
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+# vim:ft=yaml:et:ts=2:sw=2

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "danger-plugin",
     "yarn"
   ],
-  "version": "1.5.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "precommit": "lint-staged",
+    "prepare-release": "yarn install && yarn build && yarn version --new-version $APP_VERSION --no-git-tag-version",
     "commit": "git-cz",
     "commitmsg": "validate-commit-msg",
     "build": "tsc",


### PR DESCRIPTION
Inspired by changes from https://github.com/glensc/node-cached_property/pull/4

<details><summary>Package contents</summary>

```
npm notice 📦  danger-plugin-yarn@0.0.0
npm notice === Tarball Contents === 
npm notice 3.2kB  CODE_OF_CONDUCT.md
npm notice 512B   CONTRIBUTING.md   
npm notice 1.1kB  LICENSE.md        
npm notice 5.6kB  README.md         
npm notice 2.9kB  dist/index.d.ts   
npm notice 14.8kB dist/index.js     
npm notice 2.5kB  package.json      
npm notice === Tarball Details === 
npm notice name:          danger-plugin-yarn                      
npm notice version:       0.0.0                                   
npm notice filename:      danger-plugin-yarn-0.0.0.tgz            
npm notice package size:  9.8 kB                                  
npm notice unpacked size: 30.6 kB
```
</details>

See https://github.com/orta/danger-plugin-yarn/issues/49#issuecomment-1074393902

Fixes https://github.com/orta/danger-plugin-yarn/issues/49

Example run:
- https://github.com/glensc/danger-plugin-yarn/runs/5640501328?check_suite_focus=true

To finish this up:
> Project owner/maintainer: you need to fill `NPM_TOKEN` Secret in project settings having access to `danger-plugin-yarn` package upload in npm registry.

Release process:
- Create git tag and push it to GitHub
- Editing of package.json is no longer needed. Version is picked from pushed tag

cc @orta 