### PR TITLE
Check versions when npm.license is missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@types/jest": "^19.2.4",
     "@types/node": "^7.0.29",
+    "@types/semver": "^5.3.33",
     "commitizen": "^2.9.6",
     "cz-conventional-changelog": "^2.0.0",
     "danger": "*",

--- a/src/fixtures/pinpoint-npm-info.json
+++ b/src/fixtures/pinpoint-npm-info.json
@@ -1,0 +1,135 @@
+{
+  "_attachments": {},
+  "_id": "pinpoint",
+  "_rev": "5-25a718426e3c3e3763b7a8f85b9fe65b",
+  "author": {
+      "email": "curvedmark@gmail.com",
+      "name": "Glen Huang"
+  },
+  "description": "Display an arrow in a string of code to point to a location",
+  "dist-tags": {
+      "latest": "1.1.0"
+  },
+  "maintainers": [
+      {
+          "email": "curvedmark@gmail.com",
+          "name": "curvedmark"
+      }
+  ],
+  "name": "pinpoint",
+  "readme": "# pinpoint\n\nAdd line numbers and an arrow to a string of code that points to a specific location.\n\n## Installation\n\n\tnpm install pinpoint\n\n## Example\n\nWith this code:\n\n```javascript\nfunction add(left, right) {\n  return left + right;\n}\n\nconsole.log(add(1 + 1));\n```\n\nWhen being asked to point to line 2 and column 2, generates this:\n\n```javascript\n1| function add(left, right) {\n2|   return left + right;\n-----^\n3| }\n4|\n5| console.log(add(1 + 1));\n```\n## API\n\n```javascript\nvar pinpoint = require('pinpoint');\n\nvar str = pinpoint(code, options);\n```\n\n* `code` - a string of code\n* `options` - an object literal supports these options:\n\t* `line` - the line number to point to, 1-based.\n\t* `column` - the column number to point to, 1-based.\n\t* `showLines` - the number of lines to show. The pointed line will try to stay in the middle of the displays lines.\n\t* `indent` - indent string prepend to each line, before the line number.",
+  "repository": {
+      "type": "git",
+      "url": "git://github.com/curvedmark/pinpoint.git"
+  },
+  "time": {
+      "1.0.0": "2013-08-19T09:30:51.336Z",
+      "1.1.0": "2013-09-21T09:56:46.195Z",
+      "created": "2013-08-19T09:30:46.479Z",
+      "modified": "2013-09-21T09:56:46.195Z"
+  },
+  "versions": {
+      "1.0.0": {
+          "_from": ".",
+          "_id": "pinpoint@1.0.0",
+          "_npmUser": {
+              "email": "curvedmark@gmail.com",
+              "name": "curvedmark"
+          },
+          "_npmVersion": "1.3.5",
+          "author": {
+              "email": "curvedmark@gmail.com",
+              "name": "Glen Huang"
+          },
+          "bugs": {
+              "url": "https://github.com/curvedmark/pinpoint/issues"
+          },
+          "description": "Display an arrow in a string of code to point to a location",
+          "devDependencies": {
+              "coffee-script": "1.x",
+              "mocha": "1.x"
+          },
+          "directories": {
+              "lib": "lib",
+              "test": "test"
+          },
+          "dist": {
+              "shasum": "11469494e0b14816e2fbebdd88ae189ac1a97288",
+              "tarball": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.0.0.tgz"
+          },
+          "keywords": [
+              "editor"
+          ],
+          "license": "MIT",
+          "main": "lib/pinpoint.js",
+          "maintainers": [
+              {
+                  "email": "curvedmark@gmail.com",
+                  "name": "curvedmark"
+              }
+          ],
+          "name": "pinpoint",
+          "readme": "# pinpoint\n\nAdd line numbers and an arrow to a string of code that points to a specific location.\n\n## Installation\n\n\tnpm install pinpoint\n\n## Example\n\nWith this code:\n\n```javascript\nfunction add(left, right) {\n  return left + right;\n}\n\nconsole.log(add(1 + 1));\n```\n\nWhen being asked to point to line 2 and column 2, generates this:\n\n```javascript\n1| function add(left, right) {\n2|   return left + right;\n-----^\n3| }\n4|\n5| console.log(add(1 + 1));\n```\n## API\n\n```javascript\nvar pinpoint = require('pinpoint');\n\nvar str = pinpoint(code, options);\n```\n\n* `code` - a string of code\n* `options` - an object literal supports these options:\n\t* `line` - the line number to point to, 1-based.\n\t* `column` - the column number to point to, 1-based.\n\t* `showLines` - the number of lines to show. The pointed line will try to stay in the middle of the displays lines.\n\t* `indent` - indent string prepend to each line, before the line number.",
+          "readmeFilename": "README.md",
+          "repository": {
+              "type": "git",
+              "url": "git://github.com/curvedmark/pinpoint.git"
+          },
+          "scripts": {
+              "test": "mocha --bail --compilers coffee:coffee-script --ui qunit"
+          },
+          "version": "1.0.0"
+      },
+      "1.1.0": {
+          "_from": ".",
+          "_id": "pinpoint@1.1.0",
+          "_npmUser": {
+              "email": "curvedmark@gmail.com",
+              "name": "curvedmark"
+          },
+          "_npmVersion": "1.3.8",
+          "author": {
+              "email": "curvedmark@gmail.com",
+              "name": "Glen Huang"
+          },
+          "bugs": {
+              "url": "https://github.com/curvedmark/pinpoint/issues"
+          },
+          "description": "Display an arrow in a string of code to point to a location",
+          "devDependencies": {
+              "coffee-script": "1.x",
+              "mocha": "1.x"
+          },
+          "directories": {
+              "lib": "lib",
+              "test": "test"
+          },
+          "dist": {
+              "shasum": "0cf7757a6977f1bf7f6a32207b709e377388e874",
+              "tarball": "https://registry.npmjs.org/pinpoint/-/pinpoint-1.1.0.tgz"
+          },
+          "keywords": [
+              "editor"
+          ],
+          "license": "MIT",
+          "main": "lib/pinpoint.js",
+          "maintainers": [
+              {
+                  "email": "curvedmark@gmail.com",
+                  "name": "curvedmark"
+              }
+          ],
+          "name": "pinpoint",
+          "readme": "# pinpoint\n\nAdd line numbers and an arrow to a string of code that points to a specific location.\n\n## Installation\n\n\tnpm install pinpoint\n\n## Example\n\nWith this code:\n\n```javascript\nfunction add(left, right) {\n  return left + right;\n}\n\nconsole.log(add(1 + 1));\n```\n\nWhen being asked to point to line 2 and column 2, generates this:\n\n```javascript\n1| function add(left, right) {\n2|   return left + right;\n-----^\n3| }\n4|\n5| console.log(add(1 + 1));\n```\n## API\n\n```javascript\nvar pinpoint = require('pinpoint');\n\nvar str = pinpoint(code, options);\n```\n\n* `code` - a string of code\n* `options` - an object literal supports these options:\n\t* `line` - the line number to point to, 1-based.\n\t* `column` - the column number to point to, 1-based.\n\t* `showLines` - the number of lines to show. The pointed line will try to stay in the middle of the displays lines.\n\t* `indent` - indent string prepend to each line, before the line number.\n\t* `tabSize` - width of a tab character.",
+          "readmeFilename": "README.md",
+          "repository": {
+              "type": "git",
+              "url": "git://github.com/curvedmark/pinpoint.git"
+          },
+          "scripts": {
+              "test": "mocha --bail --compilers coffee:coffee-script --ui qunit"
+          },
+          "version": "1.1.0"
+      }
+  }
+}

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -126,8 +126,32 @@ describe("checkForLockfileDiff", () => {
 })
 
 describe("npm metadata", () => {
+
+  jest.mock("node-fetch", () => () =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(JSON.parse(mockfs.readFileSync("src/fixtures/danger-npm-info.json", "utf8"))),
+    }),
+  )
   it("Shows a bunch of useful text for a new dep", async () => {
-    jest.mock("node-fetch", fixtureDangerNpmInfo)
+
+    // const provideFixture2 = (fixture: string) => {
+    //   return () => () => Promise.resolve({
+    //     ok: true,
+    //     json: () => Promise.resolve(JSON.parse(mockfs.readFileSync(`src/fixtures/${fixture}.json`, "utf8"))),
+    //   })
+    // };
+    //
+    // const fixtureDangerNpmInfo2 = provideFixture2("danger-npm-info");
+    // jest.mock("node-fetch", fixtureDangerNpmInfo2)
+
+    jest.mock("node-fetch", () => () =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(JSON.parse(mockfs.readFileSync("src/fixtures/danger-npm-info.json", "utf8"))),
+      }),
+    )
+
     expect.assertions(1)
     const npmData = await getNPMMetadataForDep("danger")
     expect(_renderNPMTable({ usedInPackageJSONPaths: ["package.json"], npmData: npmData! })).toMatchSnapshot()
@@ -194,11 +218,11 @@ describe("Feature Flags", () => {
     expect(global.message).toHaveBeenCalledTimes(0)
     expect(global.warn).toHaveBeenCalledTimes(2) // Called with "Changes were made to package.json, but not […]"
     expect(global.fail).toHaveBeenCalledTimes(0)
-
-    it("looks through versions if license is missing", async () => {
-    jest.mock("node-fetch", fixturePinpointNpmInfo)
-    const { getNPMMetadataForDep } = require("./")
-    const data = await getNPMMetadataForDep("pinpoint")
-    expect(data).toMatchSnapshot()
-  })
+  //
+  //   it("looks through versions if license is missing", async () => {
+  //   // jest.mock("node-fetch", fixturePinpointNpmInfo)
+  //   const { getNPMMetadataForDep } = require("./")
+  //   const data = await getNPMMetadataForDep("pinpoint")
+  //   expect(data).toMatchSnapshot()
+  // })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -15,6 +15,13 @@ import yarn, {
   getNPMMetadataForDep,
 } from "./index"
 
+const provideFixture = (fixture: string) => {
+  return () => () => Promise.resolve({
+    ok: true,
+    json: () => Promise.resolve(JSON.parse(mockfs.readFileSync(`src/fixtures/${fixture}.json`, "utf8"))),
+  })
+};
+
 declare const global: any
 beforeEach(() => {
   global.warn = jest.fn()

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -7,6 +7,7 @@ import yarn, {
   checkForNewDependencies,
   checkForRelease,
   checkForTypesInDeps,
+  getNPMMetadataForDep,
 } from "./index"
 
 const provideFixture = (fixture: string) => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -126,7 +126,7 @@ describe("checkForLockfileDiff", () => {
 
 describe("npm metadata", () => {
   it("Shows a bunch of useful text for a new dep", async () => {
-    jest.mock("node-fetch", () => () => fixtureDangerNpmInfo)
+    jest.mock("node-fetch", fixtureDangerNpmInfo)
     expect.assertions(1)
     const npmData = await getNPMMetadataForDep("danger")
     expect(_renderNPMTable({ usedInPackageJSONPaths: ["package.json"], npmData: npmData! })).toMatchSnapshot()

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,10 +1,4 @@
 import * as mockfs from "fs"
-jest.mock("node-fetch", () => () =>
-  Promise.resolve({
-    ok: true,
-    json: () => Promise.resolve(JSON.parse(mockfs.readFileSync("src/fixtures/danger-npm-info.json", "utf8"))),
-  })
-)
 
 import yarn, {
   _operateOnSingleDiff,
@@ -21,6 +15,8 @@ const provideFixture = (fixture: string) => {
     json: () => Promise.resolve(JSON.parse(mockfs.readFileSync(`src/fixtures/${fixture}.json`, "utf8"))),
   })
 };
+
+const fixtureDangerNpmInfo = provideFixture("danger-npm-info");
 
 declare const global: any
 beforeEach(() => {
@@ -129,6 +125,7 @@ describe("checkForLockfileDiff", () => {
 
 describe("npm metadata", () => {
   it("Shows a bunch of useful text for a new dep", async () => {
+    jest.mock("node-fetch", () => () => fixtureDangerNpmInfo)
     expect.assertions(1)
     const npmData = await getNPMMetadataForDep("danger")
     expect(_renderNPMTable({ usedInPackageJSONPaths: ["package.json"], npmData: npmData! })).toMatchSnapshot()

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -4,9 +4,9 @@ import yarn, {
   _operateOnSingleDiff,
   _renderNPMTable,
   checkForLockfileDiff,
+  checkForNewDependencies,
   checkForRelease,
   checkForTypesInDeps,
-  getNPMMetadataForDep,
 } from "./index"
 
 const provideFixture = (fixture: string) => {
@@ -193,5 +193,11 @@ describe("Feature Flags", () => {
     expect(global.message).toHaveBeenCalledTimes(0)
     expect(global.warn).toHaveBeenCalledTimes(2) // Called with "Changes were made to package.json, but not […]"
     expect(global.fail).toHaveBeenCalledTimes(0)
+
+    it("looks through versions if license is missing", async () => {
+    jest.mock("node-fetch", fixturePinpointNpmInfo)
+    const { getNPMMetadataForDep } = require("./")
+    const data = await getNPMMetadataForDep("pinpoint")
+    expect(data).toMatchSnapshot()
   })
 })

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -17,6 +17,7 @@ const provideFixture = (fixture: string) => {
 };
 
 const fixtureDangerNpmInfo = provideFixture("danger-npm-info");
+const fixturePinpointNpmInfo = provideFixture("pinpoint-npm-info");
 
 declare const global: any
 beforeEach(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -210,9 +210,14 @@ export const getNPMMetadataForDep = async (
       tableDeets.push({ name: "License", message: license })
     } else {
       // License is important, so always show info
+      const { versions = {} } = npm
+      const licenses = Object.keys(versions)
+        .sort((a, b) => (semver.gte(b, a) ? 1 : 0)) // sort latest versions first
+        .map(version => versions[version].license) // get the license
+        .filter(Boolean) // remove falsy values
       tableDeets.push({
         name: "License",
-        message: "<b>NO LICENSE FOUND</b>",
+        message: `<b>${licenses[0] || "NO LICENSE FOUND"}</b>`,
       })
     }
     // Right

--- a/yarn.lock
+++ b/yarn.lock
@@ -74,6 +74,10 @@
   version "7.0.29"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.0.29.tgz#ccfcec5b7135c7caf6c4ffb8c7f33102340d99df"
 
+"@types/semver@^5.3.33":
+  version "5.3.33"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-5.3.33.tgz#58ebb6c8c48e161e24f8901915e7184900d341f7"
+
 abab@^1.0.0, abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"


### PR DESCRIPTION
Re-create https://github.com/orta/danger-plugin-yarn/pull/6

Fixes https://github.com/orta/danger-plugin-yarn/issues/5

Original description by @macklinu:
> I wanted to contribute a fix for https://github.com/orta/danger-plugin-yarn/issues/5, but it looks like I'm not mocking node-fetch properly in the tests, and I believe the danger test snapshot changed to the latest danger README (aka it's fetching data from the network in the tests). If you could help out on this, that'd be awesome. I think this is the general fix desired - open to feedback! 😄