### PR TITLE
Fix version (1.6.0) in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "danger-plugin",
     "yarn"
   ],
-  "version": "1.5.1",
+  "version": "1.6.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {


### PR DESCRIPTION
The latest release seems to be 1.6.0 (Published 3 years ago):
- https://www.npmjs.com/package/danger-plugin-yarn/v/1.6.0